### PR TITLE
Dsgvo bugfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:8.1.2'
     }
 }
 
@@ -37,12 +37,16 @@ dependencies {
 
 
 android {
+    namespace 'com.mde.potdroid'
     useLibrary 'org.apache.http.legacy'
     compileSdkVersion 28
     defaultConfig {
         minSdkVersion 17
         targetSdkVersion 28
         vectorDrawables.useSupportLibrary = true
+    }
+    buildFeatures {
+        buildConfig true
     }
     buildTypes {
         release {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.nonFinalResIds=false

--- a/src/main/java/com/mde/potdroid/fragments/BaseFragment.java
+++ b/src/main/java/com/mde/potdroid/fragments/BaseFragment.java
@@ -130,8 +130,8 @@ public abstract class BaseFragment extends Fragment implements SwipyRefreshLayou
      */
     public int getActionbarHeight() {
         TypedValue typedValue = new TypedValue();
-        getBaseActivity().getTheme().resolveAttribute(R.attr.actionBarSize, typedValue, true);
-        int[] textSizeAttr = new int[]{R.attr.actionBarSize};
+        getBaseActivity().getTheme().resolveAttribute(android.support.design.R.attr.actionBarSize, typedValue, true);
+        int[] textSizeAttr = new int[]{android.support.design.R.attr.actionBarSize};
         int indexOfAttr = 0;
         TypedArray a = getBaseActivity().obtainStyledAttributes(typedValue.data, textSizeAttr);
         int abSize = a.getDimensionPixelSize(indexOfAttr, -1);

--- a/src/main/java/com/mde/potdroid/helpers/LoginPreference.java
+++ b/src/main/java/com/mde/potdroid/helpers/LoginPreference.java
@@ -12,7 +12,7 @@ public class LoginPreference extends DialogPreference {
     }
 
     public LoginPreference(Context context, AttributeSet attrs) {
-        super(context, attrs, R.attr.dialogPreferenceStyle);
+        super(context, attrs, android.support.v7.preference.R.attr.dialogPreferenceStyle);
     }
 
     public LoginPreference(Context context, AttributeSet attrs, int defStyleAttr) {

--- a/src/main/java/com/mde/potdroid/helpers/LogoutPreference.java
+++ b/src/main/java/com/mde/potdroid/helpers/LogoutPreference.java
@@ -12,7 +12,7 @@ public class LogoutPreference extends DialogPreference {
     }
 
     public LogoutPreference(Context context, AttributeSet attrs) {
-        super(context, attrs, R.attr.dialogPreferenceStyle);
+        super(context, attrs, android.support.v7.preference.R.attr.dialogPreferenceStyle);
     }
 
     public LogoutPreference(Context context, AttributeSet attrs, int defStyleAttr) {

--- a/src/main/java/com/mde/potdroid/parsers/TopicParser.java
+++ b/src/main/java/com/mde/potdroid/parsers/TopicParser.java
@@ -364,7 +364,12 @@ public class TopicParser extends DefaultHandler {
 
             @Override
             public void start(Attributes attributes) {
-                mCurrentUser.setAvatarId(Integer.parseInt(attributes.getValue(AVATAR_ATTRIBUTE)));
+                try {
+                    mCurrentUser.setAvatarId(Integer.parseInt(attributes.getValue(AVATAR_ATTRIBUTE)));
+                } catch (NumberFormatException e) {
+                    // no avatarId in XML (user probably got deleted)
+                    mCurrentUser.setAvatarId(0);
+                }
             }
 
             @Override

--- a/src/main/java/com/mde/potdroid/views/PostActionsDialog.java
+++ b/src/main/java/com/mde/potdroid/views/PostActionsDialog.java
@@ -118,7 +118,7 @@ public class PostActionsDialog extends DialogFragment {
             }
 
             if(isEnabled) {
-                holder.mText.setTextColor(Utils.getColorByAttr(getContext(), R.attr.md_content_color));
+                holder.mText.setTextColor(Utils.getColorByAttr(getContext(), R.attr.bbTextColorPrimary));
                 holder.mRoot.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {


### PR DESCRIPTION
Hallihallo,
Potdroid kann nicht damit umgehen, wenn sich ein User hat löschen lassen. Öffnet man einen Thread mit einem Post eines gelöschten Users, crasht der Thread. Das Problem scheint zu sein, dass Potdroid versucht, eine AvatarId zu parsen und wenn diese null ist, klappt alles zusammen. Ich habe relativ wenig Ahnung von der gesamten Materie, habe aber einfach als whacky Hot Fix das Parsen der AvatarId in einen Try/Catch-Block gepackt und - sofern es keine Id gibt - diese dann genullt.
In the process, bzw. um das Projekt überhaupt lokal zum Laufen zu bekommen, musste ich das gradle Zeug anfassen. Und damit einher gingen ein paar andere Probleme.
Bei mir läuft es nun einwandfrei. Aber ich will nicht garantieren, dass meine "in the process"-Anpassungen irgendwelche Folgen haben (ich glaube aber nicht). Insgesamt habe ich auch null Ahnung von git, das ist mein erster Request. Ich hoffe, ich bediene das hier also richtig und doxxe mich nicht versehentlich.

Lieben Gruß aus dem Brunch,
Joggl