### PR TITLE
feat: use base URL as referrer

### DIFF
--- a/src/main/java/com/mde/potdroid/fragments/MediaFragment.java
+++ b/src/main/java/com/mde/potdroid/fragments/MediaFragment.java
@@ -34,6 +34,7 @@ public class MediaFragment extends BaseFragment implements OnPreparedListener {
     private boolean mVideoViewPausedInOnStop;
     public final static String ARG_URI = "uri";
     public final static String ARG_TYPE = "type";
+    public final static String ARG_REFERER = "referer";
     //private ShareActionProvider mShareActionProvider;
     private Intent mShareIntent;
 
@@ -181,12 +182,13 @@ public class MediaFragment extends BaseFragment implements OnPreparedListener {
         final Uri uri = Uri.parse(getArguments().getString(ARG_URI));
 
         String type = getArguments().getString(ARG_TYPE);
+        final String referer = getArguments().getString(ARG_REFERER);
 
         ImageHandler ih = ImageHandler.getPictureHandler(getActivity());
 
         if (type.compareTo("gif") == 0) {
             showLoadingAnimation();
-            ih.retrieveImage(uri.toString(), new ImageHandler.ImageHandlerCallback() {
+            ih.retrieveImage(uri.toString(), referer, new ImageHandler.ImageHandlerCallback() {
                 @Override
                 public void onSuccess(String url, final String path, boolean from_cache) {
                     getBaseActivity().runOnUiThread(new Runnable() {
@@ -229,7 +231,7 @@ public class MediaFragment extends BaseFragment implements OnPreparedListener {
         } else if (type.compareTo("image") == 0) {
             showLoadingAnimation();
             try {
-                ih.retrieveImage(uri.toString(), new ImageHandler.ImageHandlerCallback() {
+                ih.retrieveImage(uri.toString(), referer, new ImageHandler.ImageHandlerCallback() {
                     @Override
                     public void onSuccess(String url, final String path, boolean from_cache) {
                         getBaseActivity().runOnUiThread(new Runnable() {

--- a/src/main/java/com/mde/potdroid/fragments/TopicFragment.java
+++ b/src/main/java/com/mde/potdroid/fragments/TopicFragment.java
@@ -905,7 +905,7 @@ public class TopicFragment extends PaginateFragment implements
     public void loadImage(final String url, final String id) {
         ImageHandler ih = ImageHandler.getPictureHandler(getActivity());
         try {
-            ih.retrieveImage(url, new ImageHandler.ImageHandlerCallback() {
+            ih.retrieveImage(url, Utils.BASE_URL, new ImageHandler.ImageHandlerCallback() {
                 @Override
                 public void onSuccess(String url, String path, boolean from_cache) {
                     mJsInterface.displayImage(url, path, id);
@@ -926,6 +926,7 @@ public class TopicFragment extends PaginateFragment implements
         Intent intent = new Intent(getActivity(), MediaActivity.class);
         intent.putExtra(MediaFragment.ARG_TYPE, type);
         intent.putExtra(MediaFragment.ARG_URI, url);
+        intent.putExtra(MediaFragment.ARG_REFERER, Utils.BASE_URL);
         startActivityForResult(intent, 0);
     }
 

--- a/src/main/java/com/mde/potdroid/helpers/ImageHandler.java
+++ b/src/main/java/com/mde/potdroid/helpers/ImageHandler.java
@@ -228,6 +228,10 @@ public class ImageHandler {
      * @param url the url of the image to be retrieved.
      */
     public void retrieveImage(final String url, final ImageHandlerCallback callback) {
+        retrieveImage(url, null, callback);
+    }
+
+    public void retrieveImage(final String url, final String referer, final ImageHandlerCallback callback) {
         final Uri localUri;
         try {
             localUri = CacheContentProvider.getContentUriFromUrlOrUri(url, mDir);
@@ -243,7 +247,11 @@ public class ImageHandler {
         }
 
         Network network = new Network(mContext);
-        Request request = new Request.Builder().url(url).build();
+        Request.Builder requestBuilder = new Request.Builder().url(url);
+        if (referer != null && referer.trim().length() > 0) {
+            requestBuilder.header("Referer", referer);
+        }
+        Request request = requestBuilder.build();
         network.getHttpClient().newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {


### PR DESCRIPTION
Aktuell schickt die Anwendung beim Laden eines Bildes keinen Referrer mit. Durch die Änderung könnte ich den imgpot CDN restriktiver einstellen.