### PR TITLE
fix(webview): drop unneeded setAllowFileAccess on message / topic WebViews

### DIFF
--- a/src/main/java/com/mde/potdroid/fragments/MessageFragment.java
+++ b/src/main/java/com/mde/potdroid/fragments/MessageFragment.java
@@ -252,7 +252,6 @@ public class MessageFragment extends BaseFragment
         mWebView.getSettings().setDomStorageEnabled(true);
         mWebView.getSettings().setDefaultFontSize(mSettings.getDefaultFontSize());
         mWebView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-        mWebView.getSettings().setAllowFileAccess(true);
         mWebView.setWebChromeClient(new WebChromeClient());
         mWebView.loadData("", "text/html", "utf-8");
         mWebView.setBackgroundColor(0x00000000);

--- a/src/main/java/com/mde/potdroid/fragments/TopicFragment.java
+++ b/src/main/java/com/mde/potdroid/fragments/TopicFragment.java
@@ -228,7 +228,6 @@ public class TopicFragment extends PaginateFragment implements
         //mWebView.getSettings().setAppCacheEnabled(false);
         mWebView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         mWebView.getSettings().setLoadWithOverviewMode(true);
-        mWebView.getSettings().setAllowFileAccess(true);
         mWebView.getSettings().setMediaPlaybackRequiresUserGesture(false);
 
         // broken on 2.3.3


### PR DESCRIPTION
Closes #299.

`MessageFragment` and `TopicFragment` both set `mWebView.getSettings().setAllowFileAccess(true)`, but the only content these WebViews ever load is fed via `loadDataWithBaseURL("file:///android_asset/", ...)`. The `file:///android_asset/` scheme is special-cased by the Android WebView and works even when `setAllowFileAccess(false)` is in effect, so the flag does not enable any current code path. On API 30+ where the default is `false`, the explicit `true` actually flips the flag back on with no benefit.

Drop the one line in both fragments:

```java
mWebView.getSettings().setAllowFileAccess(true);
```

Asset loading via `file:///android_asset/` keeps working, the JS bridges keep working, and the WebViews no longer accept real `file://` URLs that no path in these fragments ever produces.
