### PR TITLE
Implement Scoped Storage using MediaStore and update permissions

### DIFF
--- a/src/main/java/com/mde/potdroid/BaseActivity.java
+++ b/src/main/java/com/mde/potdroid/BaseActivity.java
@@ -342,10 +342,17 @@ public class BaseActivity extends AppCompatActivity {
      * @param activity
      */
     public void verifyStoragePermissions(Activity activity, ExternalPermissionCallback callback) {
+        mPermissionCallback = callback;
+
+        // On Android 13+ (API 33), WRITE_EXTERNAL_STORAGE is deprecated and always denied.
+        // For saving media via MediaStore, we don't need to ask for it.
+        if (android.os.Build.VERSION.SDK_INT >= 33) {
+            mPermissionCallback.granted();
+            return;
+        }
+
         // Check if we have write permission
         int permission = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-
-        mPermissionCallback = callback;
 
         if (permission != PackageManager.PERMISSION_GRANTED) {
             // We don't have permission so prompt the user

--- a/src/main/java/com/mde/potdroid/helpers/ImageHandler.java
+++ b/src/main/java/com/mde/potdroid/helpers/ImageHandler.java
@@ -1,8 +1,12 @@
 package com.mde.potdroid.helpers;
 
+import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
 import android.os.ParcelFileDescriptor;
+import android.provider.MediaStore;
 import com.mde.potdroid.helpers.cache.DiskLruCache;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -271,26 +275,49 @@ public class ImageHandler {
     public static void downloadImage(final Context cx, File dir, final Uri uri, final ImageDownloadCallback callback) {
         ImageHandler ih = ImageHandler.getPictureHandler(cx.getApplicationContext());
 
-        final File file = new File(dir, uri.getLastPathSegment());
-
         try {
             ih.retrieveImage(uri.toString(), new ImageHandler.ImageHandlerCallback() {
                 @Override
                 public void onSuccess(String url, final String path, boolean from_cache) {
                     InputStream is = null;
+                    OutputStream os = null;
                     try {
-                        FileOutputStream fo = new FileOutputStream(file);
                         is = cx.getContentResolver().openInputStream(Uri.parse(path));
 
-                        byte[] buffer = new byte[1024];
-                        int len1;
-                        while ((len1 = is.read(buffer)) > 0) {
-                            fo.write(buffer, 0, len1);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            // Modern way: MediaStore (Android 10+)
+                            ContentValues values = new ContentValues();
+                            values.put(MediaStore.MediaColumns.DISPLAY_NAME, uri.getLastPathSegment());
+                            values.put(MediaStore.MediaColumns.MIME_TYPE, "image/*");
+                            values.put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/pOT-Droid");
+
+                            Uri imageUri = cx.getContentResolver().insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values);
+                            if (imageUri != null) {
+                                os = cx.getContentResolver().openOutputStream(imageUri);
+                            }
+                        } else {
+                            // Legacy way: File API (Pre-Android 10)
+                            if (!dir.exists()) dir.mkdirs();
+                            File file = new File(dir, uri.getLastPathSegment());
+                            os = new FileOutputStream(file);
                         }
-                        fo.close();
-                        callback.onSuccess(uri, file);
+
+                        if (os != null && is != null) {
+                            byte[] buffer = new byte[1024];
+                            int len1;
+                            while ((len1 = is.read(buffer)) > 0) {
+                                os.write(buffer, 0, len1);
+                            }
+                            os.close();
+                            callback.onSuccess(uri, null);
+                        } else {
+                            callback.onFailure(uri, new IOException("Failed to save image"));
+                        }
                     } catch (IOException e) {
                         callback.onFailure(uri, e);
+                    } finally {
+                        try { if (is != null) is.close(); } catch (IOException ignored) {}
+                        try { if (os != null) os.close(); } catch (IOException ignored) {}
                     }
                 }
 

--- a/src/main/java/com/mde/potdroid/helpers/Network.java
+++ b/src/main/java/com/mde/potdroid/helpers/Network.java
@@ -1,8 +1,12 @@
 package com.mde.potdroid.helpers;
 
 import android.app.Activity;
+import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.MediaStore;
 import okhttp3.*;
 import okio.BufferedSink;
 import okio.Okio;
@@ -10,6 +14,7 @@ import okio.Okio;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
@@ -194,8 +199,6 @@ public class Network {
     }
 
     public static void downloadFile(final Context cx, final Uri uri, final File dir, final DownloadCallback callback) {
-        final File file = new File(dir, uri.getLastPathSegment());
-
         Network network = new Network(cx.getApplicationContext());
         Request request = new Request.Builder().url(uri.toString()).build();
         network.getHttpClient().newCall(request).enqueue(new Callback() {
@@ -206,30 +209,36 @@ public class Network {
 
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                BufferedSink sink = null;
-                FileOutputStream fo = null;
+                OutputStream os = null;
                 try {
-                    fo = new FileOutputStream(file);
-                    sink = Okio.buffer(Okio.sink(fo));
-                    sink.writeAll(response.body().source());
-                    sink.close();
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        ContentValues values = new ContentValues();
+                        values.put(MediaStore.MediaColumns.DISPLAY_NAME, uri.getLastPathSegment());
+                        values.put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/pOT-Droid");
 
-                    callback.onSuccess(uri, file);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                } finally {
-                    try {
-                        if (sink != null)
-                            sink.close();
-                        if (fo != null)
-                            fo.close();
-                    } catch (IOException e) {
-                        e.printStackTrace();
+                        Uri fileUri = cx.getContentResolver().insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values);
+                        if (fileUri != null) {
+                            os = cx.getContentResolver().openOutputStream(fileUri);
+                        }
+                    } else {
+                        if (!dir.exists()) dir.mkdirs();
+                        os = new FileOutputStream(new File(dir, uri.getLastPathSegment()));
                     }
 
+                    if (os != null) {
+                        okio.BufferedSink sink = okio.Okio.buffer(okio.Okio.sink(os));
+                        sink.writeAll(response.body().source());
+                        sink.close();
+                        callback.onSuccess(uri, null);
+                    } else {
+                        callback.onFailure(uri, new IOException("Failed to create output stream"));
+                    }
+                } catch (IOException e) {
+                    callback.onFailure(uri, e);
+                } finally {
+                    if (os != null) try { os.close(); } catch (IOException ignored) {}
                     response.body().close();
                 }
-
             }
         });
     }


### PR DESCRIPTION
This PR fixes an issue where images could not be saved on Android 16 devices.

On Android 16, the previous file-saving approach no longer worked reliably due to newer storage restrictions and permission behavior. As a result, saving generated/exported images failed for affected users.

**What changed**
Migrated image saving to the scoped storage flow using MediaStore.
Updated runtime permission handling to align with modern Android versions (including Android 13+ behavior).
Improved save logic so image creation is finalized correctly in the media library.
